### PR TITLE
Validate sshd_config with sshd -t

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,10 @@
   tags: package
 
 - name: configure sshd
-  template: src=sshd_config.j2 dest={{ sshd_config_basedir }}/sshd_config
+  template: >
+    src=sshd_config.j2
+    dest={{ sshd_config_basedir }}/sshd_config
+    validate="/usr/sbin/sshd -t -f %s"
   notify: restart sshd
   tags: configuration
 


### PR DESCRIPTION
The sshd_config should be validated before reloading the server.

While `-f %s` is not necessary for sshd, Ansible always requires %s for string formatting.

I am not sure whether the path to `sshd` may be distribution specific, maybe there should be a variable for this?
