### PR TITLE
Add option for PasswordAuthentication, enable by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Port sshd is running on: 
+# Port sshd is running on:
 sshd_port: 22
 
 # Allowed settings are: yes, no, without-password
@@ -7,3 +7,6 @@ sshd_permit_root_login: yes
 
 # Allowed setting are: installed, latest
 sshd_pkg_state: installed
+
+# Allowed settings are: yes, no
+sshd_password_authentication: yes

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -46,7 +46,7 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 
 # Change to no to disable tunnelled clear text passwords
-#PasswordAuthentication yes
+PasswordAuthentication {{ sshd_password_authentication }}
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
For a bit better security, it might be useful to have an option to disable PasswordAuth (same with [X11Forwarding](https://github.com/jnv/ansible-role-sshd/tree/xfwd)).
